### PR TITLE
Bring back the global feature for cention services

### DIFF
--- a/Public/Support/Components/Helper/Helper.css
+++ b/Public/Support/Components/Helper/Helper.css
@@ -2,7 +2,7 @@
 	position: absolute;
 	background-color: #e1ffe4;
 	border: 1px solid #000;
-	max-width: 200px;
+	max-width: 270px;
 	padding: 5px;
 	-webkit-box-shadow: 1px 5px 15px #555;
 	-moz-box-shadow: 1px 5px 15px #555;

--- a/go/src/c3/auth/auth.go
+++ b/go/src/c3/auth/auth.go
@@ -10,10 +10,11 @@ import (
 	"c3/osm/workflow"
 	"c3/web/controllers"
 	// "fmt"
+	"log"
+	"net"
+
 	"github.com/cention-mujibur-rahman/gobcache"
 	"github.com/gin-gonic/gin"
-	"net"
-	"log"
 )
 
 const (
@@ -31,10 +32,10 @@ func checkingMemcache() bool {
 	return true
 }
 
-func Middleware () func (*gin.Context) {
+func Middleware() func(*gin.Context) {
 	memcacheIsRunning := checkingMemcache()
 
-	return func (ctx *gin.Context) {
+	return func(ctx *gin.Context) {
 		var currUser *workflow.User
 		cookie, err := ctx.Request.Cookie("cention-suiteSSID")
 		if err != nil {
@@ -62,31 +63,30 @@ func Middleware () func (*gin.Context) {
 						currUser = controllers.FetchUserObject(wfUser.Id)
 					} else {
 						ctx.AbortWithStatus(HTTP_UNAUTHORIZE_ACCESS)
-		}
+					}
 				} else {
 					ctx.AbortWithStatus(HTTP_UNAUTHORIZE_ACCESS)
-	}
-}
+				}
+			}
 
 		} else {
 			wfUser, err := wf.QueryUser_byHashLogin(ssid)
 			if err != nil {
 				ctx.AbortWithStatus(HTTP_UNAUTHORIZE_ACCESS)
 			}
-	
+
 			if wfUser != nil {
 				if wfUser.Active {
 					currUser = controllers.FetchUserObject(wfUser.Id)
 				} else {
 					ctx.AbortWithStatus(HTTP_UNAUTHORIZE_ACCESS)
-	}
-	
+				}
+
 			} else {
 				ctx.AbortWithStatus(HTTP_UNAUTHORIZE_ACCESS)
-	}
-}
+			}
+		}
 
-		
 		ctx.Keys = make(map[string]interface{})
 		ctx.Keys["loggedInUser"] = currUser
 		ctx.Next()

--- a/go/src/c3/feature/singleton.go
+++ b/go/src/c3/feature/singleton.go
@@ -1,0 +1,58 @@
+package feature
+
+import (
+	"sync"
+)
+
+var onlyonce sync.Once
+var protect chan int
+var singleton *Feature
+
+func getSingleton() (r *Feature) {
+    onlyonce.Do(func() {
+    	singleton = New()
+    })
+	return singleton
+}
+
+// ClearCache clears the cached features that were loaded from the object server.
+func ClearCache() {
+	protect <- 1
+	defer func() {<-protect}()
+	getSingleton().ClearCache()
+}
+
+// SetGlobalContext sets the default global context to the given context.
+func SetGlobalContext(ctx string) {
+	protect <- 1
+	defer func() {<-protect}()
+	getSingleton().SetGlobalContext(ctx)
+}
+
+// Bool returns the boolean value of the feature application state for the
+// given tag.
+func Bool(tag string) bool {
+	protect <- 1
+	defer func() {<-protect}()
+	return getSingleton().Bool(tag)
+}
+
+// Int returns the integer value of the feature application state for the given
+// tag.
+func Int(tag string) int {
+	protect <- 1
+	defer func() {<-protect}()
+	return getSingleton().Int(tag)
+}
+
+// Str returns the string value of the feature application state for the given
+// tag.
+func Str(tag string) string {
+	protect <- 1
+	defer func() {<-protect}()
+	return getSingleton().Str(tag)
+}
+
+func init() {
+	protect = make(chan int, 1)  // Allocate a buffer channel
+}

--- a/go/src/c3/feature/singleton.go
+++ b/go/src/c3/feature/singleton.go
@@ -1,31 +1,29 @@
 package feature
 
-import (
-	"sync"
-)
+import "sync"
 
 var onlyonce sync.Once
 var protect chan int
 var singleton *Feature
 
 func getSingleton() (r *Feature) {
-    onlyonce.Do(func() {
-    	singleton = New()
-    })
+	onlyonce.Do(func() {
+		singleton = New()
+	})
 	return singleton
 }
 
 // ClearCache clears the cached features that were loaded from the object server.
 func ClearCache() {
 	protect <- 1
-	defer func() {<-protect}()
+	defer func() { <-protect }()
 	getSingleton().ClearCache()
 }
 
 // SetGlobalContext sets the default global context to the given context.
 func SetGlobalContext(ctx string) {
 	protect <- 1
-	defer func() {<-protect}()
+	defer func() { <-protect }()
 	getSingleton().SetGlobalContext(ctx)
 }
 
@@ -33,7 +31,7 @@ func SetGlobalContext(ctx string) {
 // given tag.
 func Bool(tag string) bool {
 	protect <- 1
-	defer func() {<-protect}()
+	defer func() { <-protect }()
 	return getSingleton().Bool(tag)
 }
 
@@ -41,7 +39,7 @@ func Bool(tag string) bool {
 // tag.
 func Int(tag string) int {
 	protect <- 1
-	defer func() {<-protect}()
+	defer func() { <-protect }()
 	return getSingleton().Int(tag)
 }
 
@@ -49,10 +47,10 @@ func Int(tag string) int {
 // tag.
 func Str(tag string) string {
 	protect <- 1
-	defer func() {<-protect}()
+	defer func() { <-protect }()
 	return getSingleton().Str(tag)
 }
 
 func init() {
-	protect = make(chan int, 1)  // Allocate a buffer channel
+	protect = make(chan int, 1) // Allocate a buffer channel
 }

--- a/webframework/Plugins/GUIKit.plugin/Components/Page.feh
+++ b/webframework/Plugins/GUIKit.plugin/Components/Page.feh
@@ -659,6 +659,7 @@ namespace modifies GUIKit {
 					 'soundmanager2-nodebug-jsmin',
 					 'Component/Component.js',
 					 'react/react-with-addons',
+					 'socket.io-client/socket.io',
 					 'requirejs/require',
 					 'jquery.datetimepicker'];
 		function requiredJavascriptExceptions 


### PR DESCRIPTION
cention services does not require gin framework. Using global
variable feature should not cause any problem. Moreover, this
commit modification use object feature and also put in thread
safe access to the global. It is a singleton object from
feature type.

workflow-fetch/send requires some kind of global setting. By
letting the feature package handle the global variable can
reduce the complication of using feature package.